### PR TITLE
You will be missed Carolyn

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ This area is intended to rejoice in them, their contributions, and to keep their
 * [Dan Kohn](dan-kohn.md)
 * [Peeyush Gupta](peeyush-gupta.md)
 * [Cody Crudgington](cody-crudgington.md)
+* [Carolyn Van Slyck](carolyn-van-slyck.md)

--- a/carolyn-van-slyck.md
+++ b/carolyn-van-slyck.md
@@ -1,0 +1,17 @@
+# In Memory of Carolyn Van Slyck
+
+Dear community and friends,
+
+I thought it might be a good idea for us all to gather our thoughts, memories and stories of Carolyn and what she meant to us in one place. Please add your contribution below via a pull request. 
+
+## Jeremy Rickard
+
+Carolyn was the kindest person that I have had the pleasure of knowing. We started working together in 2017 and I immediately realized how fortunate I was to be able to work with her. She was generous with both her time and knowledge, and she cared deeply about the people and communities she was involved in. She always worked to build up the people around her and to identify opportunities for all and worked toward healthy and inclusive communities. We worked on a number of things together, but starting the [Porter](https://porter.sh) project with her is one of the highlights of my career. Watching her welcome and guide new contributors was so inspiring. Her dedication to the community, especially through her service on the Kubernetes Code of Conduct committee and her contributions to TAG Contributor Strategy deserve to be honored. 
+
+Carolyn was an amazing friend, both at work and outside. 2020 was a really tough year for me personally and Carolyn was always there to check in on me and play Animal Crossing. Her friendship meant a great deal to me and I'll miss her very much. 
+
+Rest in peace, Carolyn. 🌈 ✨
+
+
+
+  


### PR DESCRIPTION
Adding a memorial page for Carolyn Van Slyck, who passed away on April 27th. 